### PR TITLE
Convert units from Russian to English notation

### DIFF
--- a/template_nut.xml
+++ b/template_nut.xml
@@ -158,7 +158,7 @@
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
-                            <units>В</units>
+                            <units>v</units>
                             <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
@@ -246,7 +246,7 @@
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
-                            <units>Гц</units>
+                            <units>Hz</units>
                             <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
@@ -290,7 +290,7 @@
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
-                            <units>В</units>
+                            <units>v</units>
                             <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
@@ -334,7 +334,7 @@
                             <status>0</status>
                             <value_type>0</value_type>
                             <allowed_hosts/>
-                            <units>В</units>
+                            <units>v</units>
                             <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
@@ -970,7 +970,7 @@
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
-                            <units>Вт</units>
+                            <units>w</units>
                             <delta>0</delta>
                             <snmpv3_contextname/>
                             <snmpv3_securityname/>
@@ -1339,7 +1339,7 @@
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{NUT UPS:upsmon[{#UPSNAME},ups.status].last(0)}=10</expression>
-                            <name>UPS {#UPSNAME} status - overloadа</name>
+                            <name>UPS {#UPSNAME} status - overload</name>
                             <url/>
                             <status>0</status>
                             <priority>5</priority>


### PR DESCRIPTION
I noticed you forked my Zabbix-NUT-Template-English repository and made some changes for it to work with pfSense.

That's great but I wasn't done. I forgot to convert all the Russian unit notation to English measurements so i finally got around to it.

Here's a PR, feel free to close if you don't want it.